### PR TITLE
fix MessageCodec Decode

### DIFF
--- a/protobsoncodec/message_codec.go
+++ b/protobsoncodec/message_codec.go
@@ -39,7 +39,7 @@ func (c *MessageCodec) DecodeValue(dc bsoncodec.DecodeContext, vr bsonrw.ValueRe
 			Received: v,
 		}
 	}
-	return c.StructCodec.DecodeValue(dc, vr, v.Elem())
+	return c.StructCodec.DecodeValue(dc, vr, v)
 }
 
 // NewMessageCodec returns a MessageCodec with options opts.


### PR DESCRIPTION
Inside bson decode the code is doing something different to Encode:

```go
	rval := reflect.ValueOf(val)
	switch rval.Kind() {
	case reflect.Ptr:
		if rval.IsNil() {
			return ErrDecodeToNil
		}
		rval = rval.Elem()
	case reflect.Map:
		if rval.IsNil() {
			return ErrDecodeToNil
		}
	default:
		return fmt.Errorf("argument to Decode must be a pointer or a map, but got %v", rval)
	}
```